### PR TITLE
Changed kombu from 4.2.2 to 4.2.2.post1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ geoip2==2.9.0
 idna==2.8
 itsdangerous==1.1.0
 Jinja2==2.10
-kombu==4.2.2
+kombu==4.2.2.post1
 MarkupSafe==1.1.0
 netaddr==0.7.19
 pyasn==1.6.0b1


### PR DESCRIPTION
kombu 4.2.2 was withdrawn by the author and replaced by 4.2.2.post1. See https://github.com/celery/kombu/issues/966.