### PR TITLE
Update README.rst to reflect relative path during installation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,10 @@ Check out netinfo to `/opt/`::
 
     $ cd /opt && git clone https://github.com/9b/netinfo.git
 
+Change directory to the `netinfo` working directory::
+
+    $ cd netinfo/
+
 Setup the virtualenv::
 
     $ virtualenv -p python3 venv3


### PR DESCRIPTION
First, thanks for publishing this. Gonna be a huge help 😄 

Second, while working through the installation instructions, I hit a snag that assumed the creation of the `venv3` from the `/opt/netinfo` directory.  The previous instruction has you in `/opt`, so I updated the `README.rst` with an extra step to change to the `netinfo` directory.

Take it or leave it; thanks all the same!